### PR TITLE
Feat/revise nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,24 +5,6 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
         "lastModified": 1705309234,
         "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
@@ -70,14 +52,14 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "systems": "systems_2"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
         in
         {
           default = with pkgs; mkShell {
-            buildInputs = [
+            packages = [
               openssl
               pkg-config
               rust-toolchain

--- a/flake.nix
+++ b/flake.nix
@@ -32,11 +32,16 @@
         in
         {
           default = with pkgs; mkShell {
+            strictDeps = true;
             packages = [
               openssl
               pkg-config
               rust-toolchain
             ];
+            OPENSSL_LIB_DIR = "${openssl.out}/lib";
+            OPENSSL_ROOT_DIR = "${openssl.out}";
+            OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+            # RUST_BACKTRACE = 1;
           };
         });
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,36 +2,44 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    flake-utils.url = "github:numtide/flake-utils";
+    systems = {
+      url = "github:nix-systems/default";
+      flake = false;
+    };
   };
-  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        overlays = [
-          (import rust-overlay)
-        ];
-        pkgs = import nixpkgs {
-          inherit system overlays;
-        };
-        rust-version = "latest";
-        rust-toolchain = pkgs.rust-bin.stable.${rust-version}.default.override
-          {
-            extensions = [
-              "rust-src"
-              "rust-analyzer"
+  outputs = { self, nixpkgs, rust-overlay, systems }:
+    let
+      inherit (nixpkgs) lib;
+      eachSystem = lib.genAttrs (import systems);
+      pkgsFor = eachSystem (system:
+        import nixpkgs {
+          localSystem = system;
+          overlays = [ rust-overlay.overlays.default ];
+        });
+    in
+    {
+      devShells = eachSystem (system:
+        let
+          pkgs = pkgsFor.${system};
+          rust-version = "latest";
+          rust-toolchain = pkgs.rust-bin.stable.${rust-version}.default.override
+            {
+              extensions = [
+                "rust-src"
+                "rust-analyzer"
+              ];
+            };
+        in
+        {
+          default = with pkgs; mkShell {
+            buildInputs = [
+              openssl
+              pkg-config
+              rust-toolchain
             ];
           };
-      in
-      {
-        devShell = with pkgs; mkShell {
-          buildInputs = [
-            openssl
-            pkg-config
-            rust-toolchain
-          ];
-        };
-        formatter = pkgs.nixpkgs-fmt;
-      }
-    );
+        });
+
+      formatter = eachSystem (system: pkgsFor.${system}.nixpkgs-fmt);
+    };
 }
-  


### PR DESCRIPTION
[flake: inputs: remove flake-utils](https://github.com/kuviman/kuvibot/commit/fe3eff0888a6fe4f6e000a069dcc618ca0ad23ac)

Why? You don't need it: https://ayats.org/blog/no-flake-utils/

As for `systems`, this is a useful abstraction that allows you to
specify a list of systems either as a file (`url =
"path:./flake.systems.nix"`) or by the default repository as shown.

Read up: https://github.com/nix-systems/nix-systems

This was the biggest selling point of `flake-utils`, but `nix-systems`
is a simpler (and more easily composable) abstraction.

[flake: devShell: rename buildInputs to packages](https://github.com/kuviman/kuvibot/commit/332259099cdfadf6b3dd95dd6856b0c61a3a159c)

Why? Because `mkShell` is smart, and everyone uses it wrong.

See:
https://github.com/NixOS/nixpkgs/blob/e21a8a42932d10970574002882041bbf6c14ca59/doc/build-helpers/special/mkshell.section.md?plain=1#L26-L27
https://github.com/NixOS/nixpkgs/blob/529a53c13fe7b403fd81da362197f561d1ca6bbe/pkgs/build-support/mkshell/default.nix#L19-L22