### PR TITLE
Feat/init rustfmt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,28 +21,34 @@
       devShells = eachSystem (system:
         let
           pkgs = pkgsFor.${system};
-          rust-version = "latest";
-          rust-toolchain = pkgs.rust-bin.stable.${rust-version}.default.override
-            {
-              extensions = [
-                "rust-src"
-                "rust-analyzer"
-              ];
-            };
+          rust-stable = pkgs.rust-bin.stable.latest.minimal.override {
+            extensions = [ "rust-src" "rust-docs" "clippy" ];
+          };
         in
         {
-          default = with pkgs; mkShell {
-            strictDeps = true;
-            packages = [
-              openssl
-              pkg-config
-              rust-toolchain
-            ];
-            OPENSSL_LIB_DIR = "${openssl.out}/lib";
-            OPENSSL_ROOT_DIR = "${openssl.out}";
-            OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
-            # RUST_BACKTRACE = 1;
-          };
+          default = with pkgs;
+            mkShell {
+              strictDeps = true;
+              packages = [
+                # Derivations in `rust-stable` take precedence over nightly.
+                (lib.hiPrio rust-stable)
+
+                # Use rustfmt, and other tools that require nightly features.
+                (pkgs.rust-bin.selectLatestNightlyWith
+                  (toolchain:
+                    toolchain.minimal.override {
+                      extensions = [ "rustfmt" "rust-analyzer" ];
+                    }))
+
+                # Native transitive dependencies for Cargo
+                pkg-config
+                openssl
+              ];
+              OPENSSL_LIB_DIR = "${openssl.out}/lib";
+              OPENSSL_ROOT_DIR = "${openssl.out}";
+              OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+              # RUST_BACKTRACE = 1;
+            };
         });
 
       formatter = eachSystem (system: pkgsFor.${system}.nixpkgs-fmt);

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,15 @@
+# Requires nightly build of rustfmt
+unstable_features = true
+
+# Enforce line endings, though this should be handled by Git
+newline_style = "Unix"
+# Keep string literals under the `max_width` with a backslash
+format_strings = true
+# Format code blocks in documentation
+format_code_in_doc_comments = true
+# Force a consistent style with macro patterns
+format_macro_matchers = true
+# Force imports to be grouped by deepest module per crate
+imports_granularity = "Module"
+# Group stock, external, and current crate imports together with newline
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
Current base commit: cb89e80afb78075c211a0d4c0e105f1fdda555b5
Prerequisites for current base commit: #2

Let's discuss what should be in `rustfmt.toml`.

The two options below match what I saw you doing by hand on stream.

```toml
# Force imports to be grouped by deepest module per crate
imports_granularity = "Module"
# Group stock, external, and current crate imports together with newline
group_imports = "StdExternalCrate"
```

This is the only real reason to have Rustfmt, the rest of the options are preferences I've collected over the years. Pretty minimal already.