### PR TITLE
Flake: switch formatter to nixfmt-classic from nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711681563,
-        "narHash": "sha256-rY/L4ZpFZRJDVoUsOqtpk3/8A8/l3RjYgMXmQc3uw3w=",
+        "lastModified": 1719468428,
+        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b09bde6e3fc9493b6a8b2a5702ac87c66505c64",
+        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,21 +18,16 @@
           localSystem = system;
           overlays = [ rust-overlay.overlays.default ];
         });
-    in
-    {
+    in {
       apps = eachSystem (system:
         let
           pkgs = pkgsFor.${system};
           craneLib = crane.mkLib pkgs;
           kuvibot = craneLib.buildPackage {
             src = craneLib.cleanCargoSource ./.;
-            buildInputs = with pkgs;[
-              pkg-config
-              openssl
-            ];
+            buildInputs = with pkgs; [ pkg-config openssl ];
           };
-        in
-        {
+        in {
           default = {
             type = "app";
             program = "${kuvibot}/bin/kuvibot";
@@ -44,8 +39,7 @@
           rust-stable = pkgs.rust-bin.stable.latest.minimal.override {
             extensions = [ "rust-src" "rust-docs" "clippy" ];
           };
-        in
-        {
+        in {
           default = with pkgs;
             mkShell {
               strictDeps = true;
@@ -54,11 +48,10 @@
                 (lib.hiPrio rust-stable)
 
                 # Use rustfmt, and other tools that require nightly features.
-                (pkgs.rust-bin.selectLatestNightlyWith
-                  (toolchain:
-                    toolchain.minimal.override {
-                      extensions = [ "rustfmt" "rust-analyzer" ];
-                    }))
+                (pkgs.rust-bin.selectLatestNightlyWith (toolchain:
+                  toolchain.minimal.override {
+                    extensions = [ "rustfmt" "rust-analyzer" ];
+                  }))
 
                 # Native transitive dependencies for Cargo
                 pkg-config

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,6 @@
             };
         });
 
-      formatter = eachSystem (system: pkgsFor.${system}.nixpkgs-fmt);
+      formatter = eachSystem (system: pkgsFor.${system}.nixfmt-classic);
     };
 }


### PR DESCRIPTION
After the debacle surrounding the stupid RFCs being accepted to change the codestyle of nixfmt from the comfortable and familiar, there was evidently enough protest to warrant a new package, `nixfmt-classic`, to be introduced to Nixpkgs.

This solves two problems:

- Dumb, horrible, contemptible formatting that is incompatible with Git merging and human brains,
- A very large dependency tree that must be brought to solve the above issue.