### PR TITLE
Flake: introduce `packages` output

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711681563,
-        "narHash": "sha256-rY/L4ZpFZRJDVoUsOqtpk3/8A8/l3RjYgMXmQc3uw3w=",
+        "lastModified": 1719468428,
+        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b09bde6e3fc9493b6a8b2a5702ac87c66505c64",
+        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,21 +18,16 @@
           localSystem = system;
           overlays = [ rust-overlay.overlays.default ];
         });
-    in
-    {
+    in {
       apps = eachSystem (system:
         let
           pkgs = pkgsFor.${system};
           craneLib = crane.mkLib pkgs;
           kuvibot = craneLib.buildPackage {
             src = craneLib.cleanCargoSource ./.;
-            buildInputs = with pkgs;[
-              pkg-config
-              openssl
-            ];
+            buildInputs = with pkgs; [ pkg-config openssl ];
           };
-        in
-        {
+        in {
           default = {
             type = "app";
             program = "${kuvibot}/bin/kuvibot";
@@ -44,8 +39,7 @@
           rust-stable = pkgs.rust-bin.stable.latest.minimal.override {
             extensions = [ "rust-src" "rust-docs" "clippy" ];
           };
-        in
-        {
+        in {
           default = with pkgs;
             mkShell {
               strictDeps = true;
@@ -54,11 +48,10 @@
                 (lib.hiPrio rust-stable)
 
                 # Use rustfmt, and other tools that require nightly features.
-                (pkgs.rust-bin.selectLatestNightlyWith
-                  (toolchain:
-                    toolchain.minimal.override {
-                      extensions = [ "rustfmt" "rust-analyzer" ];
-                    }))
+                (pkgs.rust-bin.selectLatestNightlyWith (toolchain:
+                  toolchain.minimal.override {
+                    extensions = [ "rustfmt" "rust-analyzer" ];
+                  }))
 
                 # Native transitive dependencies for Cargo
                 pkg-config

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,11 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    rust-overlay.url = "github:oxalica/rust-overlay";
     systems = {
       url = "github:nix-systems/default";
       flake = false;
     };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
     crane.url = "github:ipetkov/crane";
     crane.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -19,20 +19,27 @@
           overlays = [ rust-overlay.overlays.default ];
         });
     in {
-      apps = eachSystem (system:
+      apps = eachSystem (system: {
+        default = self.apps.${system}.kuvibot;
+        kuvibot = {
+          type = "app";
+          program = lib.getExe self.packages.${system}.kuvibot;
+        };
+      });
+
+      packages = eachSystem (system:
         let
           pkgs = pkgsFor.${system};
           craneLib = crane.mkLib pkgs;
+        in {
+          default = self.packages.${system}.kuvibot;
           kuvibot = craneLib.buildPackage {
             src = craneLib.cleanCargoSource ./.;
             buildInputs = with pkgs; [ pkg-config openssl ];
-          };
-        in {
-          default = {
-            type = "app";
-            program = "${kuvibot}/bin/kuvibot";
+            meta.mainProgram = "kuvibot";
           };
         });
+
       devShells = eachSystem (system:
         let
           pkgs = pkgsFor.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,6 @@
             };
         });
 
-      formatter = eachSystem (system: pkgsFor.${system}.nixpkgs-fmt);
+      formatter = eachSystem (system: pkgsFor.${system}.nixfmt-classic);
     };
 }


### PR DESCRIPTION
The first commit in this PR is part of #4. It will be dropped when this is merged, there is no need for a rebase.

This PR introduces the `packages` output with `kuvibot` and `default` derivations. They are the same.

It is worth noting that when there is a `default` derivation, an app output is optional and redundant. It may be removed.

Also, the default devShell is left alone, though it could also me merged/overridden from the package. Nevertheless, it functions as a general "Rust with OpenSSL" environment and because of this I have not touched it.